### PR TITLE
use x86-64 ndk toolchain on arm64 darwin hosts, fixes #175

### DIFF
--- a/android.sh
+++ b/android.sh
@@ -296,7 +296,11 @@ if [[ -n ${ANDROID_ARCHITECTURES} ]]; then
 
   # BUILD NATIVE LIBRARY
   if [[ ${SKIP_ffmpeg_kit} -ne 1 ]]; then
-    "${ANDROID_NDK_ROOT}"/ndk-build -B 1>>"${BASEDIR}"/build.log 2>&1
+    if [ "$(is_darwin_arm64)" == "1" ]; then
+       arch -x86_64 "${ANDROID_NDK_ROOT}"/ndk-build -B 1>>"${BASEDIR}"/build.log 2>&1
+    else
+      "${ANDROID_NDK_ROOT}"/ndk-build -B 1>>"${BASEDIR}"/build.log 2>&1
+    fi
 
     if [ $? -eq 0 ]; then
       echo "ok"

--- a/scripts/function-android.sh
+++ b/scripts/function-android.sh
@@ -109,6 +109,17 @@ get_clang_host() {
   esac
 }
 
+is_darwin_arm64() {
+  HOST_OS=$(uname -s)
+  HOST_ARCH=$(uname -m)
+
+  if [ "${HOST_OS}" == "Darwin" ] && [ "${HOST_ARCH}" == "arm64" ]; then
+    echo "1"
+  else
+    echo "0"
+  fi
+}
+
 get_toolchain() {
   HOST_OS=$(uname -s)
   case ${HOST_OS} in
@@ -123,6 +134,12 @@ get_toolchain() {
   i?86) HOST_ARCH=x86 ;;
   x86_64 | amd64) HOST_ARCH=x86_64 ;;
   esac
+
+  if [ "$(is_darwin_arm64)" == "1" ]; then
+    # NDK DOESNT HAVE AN ARM64 TOOLCHAIN ON DARWIN
+    # WE USE x86-64 WITH ROSETTA INSTEAD
+    HOST_ARCH=x86_64
+  fi
 
   echo "${HOST_OS}-${HOST_ARCH}"
 }


### PR DESCRIPTION
## Description
Fixes android build scripts on Darwin arm64 architecture

## Type of Change
- New feature

## Checks
- [ x ] Changes support all platforms (`Android`, `iOS`, `macOS`, `tvOS`)
- [ - ] Breaks existing functionality
- [ x ] Implementation is completed, not half-done 
- [ - ] Is there another PR already created for this feature/bug fix