### PR TITLE
implement get chapters api in media information

### DIFF
--- a/flutter/flutter/lib/chapter.dart
+++ b/flutter/flutter/lib/chapter.dart
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2019-2021 Taner Sener
+ *
+ * This file is part of FFmpegKit.
+ *
+ * FFmpegKit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * FFmpegKit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with FFmpegKit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class Chapter {
+  int id;
+  String timeBase;
+  int start;
+  int end;
+  String startTime;
+  String endTime;
+  Tags tags;
+
+  Chapter(this.id, this.timeBase, this.start, this.end, this.startTime,
+      this.endTime, this.tags);
+}
+
+class Tags {
+  String title;
+
+  Tags(this.title);
+}

--- a/flutter/flutter/lib/media_information.dart
+++ b/flutter/flutter/lib/media_information.dart
@@ -17,6 +17,7 @@
  * along with FFmpegKit.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import 'chapter.dart';
 import 'stream_information.dart';
 
 /// Media information class.
@@ -84,6 +85,28 @@ class MediaInformation {
       createStreamInformation(stream as Map<dynamic, dynamic>);
     });
 
+    return list;
+  }
+
+  /// Returns all chapters
+  List<Chapter> getChapters() {
+    final List<Chapter> list = List<Chapter>.empty(growable: true);
+    List<Chapter> chapters = List.empty(growable: true);
+    if (_allProperties?["chapters"] != null) {
+      chapters = <Chapter>[];
+      _allProperties!['chapters'].forEach((dynamic chapter) {
+        final int id = chapter['id'];
+        final String timeBase = chapter['time_base'];
+        final int start = chapter['start'];
+        final int end = chapter['end'];
+        final String startTime = chapter['start_time'];
+        final String endTime = chapter['end_time'];
+        final Tags tags = Tags(chapter['tags']['title'] ?? "");
+        chapters.add(
+            new Chapter(id, timeBase, start, end, startTime, endTime, tags));
+      });
+    }
+    list.addAll(chapters);
     return list;
   }
 


### PR DESCRIPTION
## Description
Added getChapters method in MediaInformation to get information about the chapters in the media file.(m4b)
Motivation:
https://stackoverflow.com/questions/67953333/how-can-i-get-the-information-regarding-m4b-m4a-file-chapters
https://stackoverflow.com/questions/68103204/flutter-retrieve-ffprobe-data
With this API, user can get the chapter's information easily by using getMediaInformationFromCommandArgumentsAsync([ "-v", "error", "-print_format", "json", "-show_chapters", "-show_format", "-show_streams", "-i", path ]) just need to make sure we add -show_chapters

## Type of Change
- Enhancement

## Checks
- [ ] Changes support all platforms (`Android`, `iOS`, `macOS`, `tvOS`)

## Tests
WIP