### PR TITLE
allow disabling bitcode in ios and tvos

### DIFF
--- a/ios.sh
+++ b/ios.sh
@@ -71,6 +71,9 @@ while [ ! $# -eq 0 ]; do
 
     skip_library "${SKIP_LIBRARY}"
     ;;
+  --no-bitcode)
+    export NO_BITCODE="1"
+    ;;
   --no-framework)
     NO_FRAMEWORK="1"
     ;;

--- a/scripts/apple/ffmpeg.sh
+++ b/scripts/apple/ffmpeg.sh
@@ -98,6 +98,10 @@ x86-64-mac-catalyst)
   ;;
 esac
 
+if [ ! -z $NO_BITCODE ]; then
+  BITCODE_FLAGS=""
+fi
+
 CONFIGURE_POSTFIX=""
 HIGH_PRIORITY_LDFLAGS=""
 

--- a/scripts/function.sh
+++ b/scripts/function.sh
@@ -927,6 +927,9 @@ display_help_advanced_options() {
   if [ -n "$1" ]; then
     echo -e "$1"
   fi
+  if [ -n "$2" ]; then
+    echo -e "$2"
+  fi
   echo -e ""
 }
 

--- a/tvos.sh
+++ b/tvos.sh
@@ -71,6 +71,9 @@ while [ ! $# -eq 0 ]; do
 
     skip_library "${SKIP_LIBRARY}"
     ;;
+  --no-bitcode)
+    export NO_BITCODE="1"
+    ;;
   --no-framework)
     NO_FRAMEWORK="1"
     ;;


### PR DESCRIPTION
## Description
Allow disabling bitcode in ios and tvos build scripts.

## Type of Change
- New feature

## Checks
- [x] Changes support all platforms (`Android`, `iOS`, `Linux`, `macOS`, `tvOS`)
- [ ] Breaks existing functionality
- [x] Implementation is completed, not half-done 

## Tests
Manually tested!