### PR TITLE
Fix MissingPluginException error when calling this plugin in an Andro…

### DIFF
--- a/flutter/flutter/android/src/main/java/com/arthenica/ffmpegkit/flutter/FFmpegKitFlutterPlugin.java
+++ b/flutter/flutter/android/src/main/java/com/arthenica/ffmpegkit/flutter/FFmpegKitFlutterPlugin.java
@@ -161,7 +161,8 @@ public class FFmpegKitFlutterPlugin implements FlutterPlugin, ActivityAware, Met
             return;
         }
         FFmpegKitFlutterPlugin plugin = new FFmpegKitFlutterPlugin();
-        plugin.init(registrar.messenger(), context, registrar.activity(), registrar, null);
+        plugin.init(registrar.messenger(), context);
+        registrar.addActivityResultListener(plugin);
     }
 
     protected void registerGlobalCallbacks() {
@@ -185,6 +186,7 @@ public class FFmpegKitFlutterPlugin implements FlutterPlugin, ActivityAware, Met
     @Override
     public void onAttachedToEngine(@NonNull final FlutterPluginBinding flutterPluginBinding) {
         this.flutterPluginBinding = flutterPluginBinding;
+        init(flutterPluginBinding.getBinaryMessenger(), flutterPluginBinding.getApplicationContext());
     }
 
     @Override
@@ -195,7 +197,8 @@ public class FFmpegKitFlutterPlugin implements FlutterPlugin, ActivityAware, Met
     @Override
     public void onAttachedToActivity(@NonNull ActivityPluginBinding activityPluginBinding) {
         Log.d(LIBRARY_NAME, String.format("FFmpegKitFlutterPlugin %s attached to activity %s.", this, activityPluginBinding.getActivity()));
-        init(flutterPluginBinding.getBinaryMessenger(), flutterPluginBinding.getApplicationContext(), activityPluginBinding.getActivity(), null, activityPluginBinding);
+        this.activity = activityPluginBinding.getActivity();
+        activityPluginBinding.addActivityResultListener(this);
     }
 
     @Override
@@ -648,7 +651,7 @@ public class FFmpegKitFlutterPlugin implements FlutterPlugin, ActivityAware, Met
     }
 
     @SuppressWarnings("deprecation")
-    protected void init(final BinaryMessenger messenger, final Context context, final Activity activity, final io.flutter.plugin.common.PluginRegistry.Registrar registrar, final ActivityPluginBinding activityBinding) {
+    protected void init(final BinaryMessenger messenger, final Context context) {
         registerGlobalCallbacks();
 
         if (methodChannel == null) {
@@ -666,17 +669,8 @@ public class FFmpegKitFlutterPlugin implements FlutterPlugin, ActivityAware, Met
         }
 
         this.context = context;
-        this.activity = activity;
 
-        if (registrar != null) {
-            // V1 embedding setup for activity listeners.
-            registrar.addActivityResultListener(this);
-        } else {
-            // V2 embedding setup for activity listeners.
-            activityBinding.addActivityResultListener(this);
-        }
-
-        Log.d(LIBRARY_NAME, String.format("FFmpegKitFlutterPlugin %s initialised with context %s and activity %s.", this, context, activity));
+        Log.d(LIBRARY_NAME, String.format("FFmpegKitFlutterPlugin %s initialised with context %s ", this, context));
     }
 
     protected void uninit() {


### PR DESCRIPTION
…id background service because `init()` method is only invoked on `onAttachedToActivity()` method, which is not available in the background service.

 - Change calling `init()` to `onAttachedToEngine` instead

## Description
MissingPluginException error is raised when calling this plugin in Android background service because `init()` method is only invoked on `onAttachedToActivity()` method, which is not available in the background service.
- Fixing it by moving `init()` method to `onAttachedToEngine()`

## Type of Change
- Bug fix

## Checks
- [ ] Changes support all platforms (`Android`)
