### PR TITLE
[Flutter] AGP8 compatibility

### DIFF
--- a/flutter/flutter/android/build.gradle
+++ b/flutter/flutter/android/build.gradle
@@ -19,6 +19,11 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.arthenica.ffmpegkit.flutter'
+    }
+
     compileSdkVersion 31
 
     defaultConfig {


### PR DESCRIPTION
## Description
Added the namespace to the Flutter Android plugin so that it is compatible with projects using AGP 8.

## Type of Change
- Bug fix

## Checks
- [x] Changes support all platforms (`Android`, `iOS`, `Linux`, `macOS`, `tvOS`)
- [ ] Breaks existing functionality
- [x] Implementation is completed, not half-done 
- [ ] Is there another PR already created for this feature/bug fix

## Tests
Can be tested in a project using AGP 8. This particular fix has been used in many packages already.