### PR TITLE
release react-native v6.0.1

### DIFF
--- a/react-native/android/build.gradle
+++ b/react-native/android/build.gradle
@@ -35,8 +35,8 @@ android {
   defaultConfig {
     minSdkVersion safeExtGet('ffmpegKitPackage', 'https').contains("-lts") ? 16 : 24
     targetSdkVersion 33
-    versionCode 600
-    versionName "6.0.0"
+    versionCode 601
+    versionName "6.0.1"
   }
 
   buildTypes {

--- a/react-native/android/gradle.properties
+++ b/react-native/android/gradle.properties
@@ -1,3 +1,3 @@
 android.useAndroidX=true
-ffmpegKit.android.main.version=6.0
-ffmpegKit.android.lts.version=6.0
+ffmpegKit.android.main.version=6.0-1
+ffmpegKit.android.lts.version=6.0-1

--- a/react-native/package.json
+++ b/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffmpeg-kit-react-native",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "FFmpeg Kit for React Native",
   "main": "src/index",
   "types": "src/index.d.ts",

--- a/react-native/src/index.js
+++ b/react-native/src/index.js
@@ -1611,7 +1611,7 @@ class FFmpegKitFactory {
   }
 
   static getVersion() {
-    return "6.0.0";
+    return "6.0.1";
   }
 
   static getLogRedirectionStrategy(sessionId) {


### PR DESCRIPTION
## Description
merge react-native v6.0.1 to main

## Type of Change
- Patch

## Checks
- [x] Changes support all platforms (`Android`, `iOS`, `Linux`, `macOS`, `tvOS`)
- [ ] Breaks existing functionality
- [x] Implementation is completed, not half-done 
- [ ] Is there another PR already created for this feature/bug fix

## Tests
Tested by the test applications in the ffmpeg-kit-test repo