### PR TITLE
use macos-13 in periodic apple builds

### DIFF
--- a/.github/workflows/periodic-builds-apple.yml
+++ b/.github/workflows/periodic-builds-apple.yml
@@ -5,12 +5,38 @@ on:
     - cron:  '0 1 * * 0'
 
 jobs:
-  build-ios-main-on-macos-monterey:
-    name: ios main on monterey
+  build-ios-main-on-macos-ventura:
+    name: ios main on ventura
+    runs-on: macos-13
+    strategy:
+      matrix:
+        xcode: [ '14.3.1' ]
+        branches: [ 'main', 'development' ]
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ matrix.branches }}
+      - name: prerequisites
+        run: brew install autoconf automake libtool pkg-config curl git doxygen nasm cmake gcc gperf texinfo yasm bison autogen wget gettext meson ninja ragel groff gtk-doc libtasn1 --overwrite
+      - name: set up xcode
+        run: echo "export DEVELOPER_DIR=/Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer" > ~/.xcode.for.ffmpeg.kit.sh
+      - name: run the build script
+        run: PATH="/usr/local/opt/bison/bin:$PATH" XML_CATALOG_FILES="/usr/local/etc/xml/catalog" ./ios.sh -x --full --enable-gpl --disable-lib-srt --disable-lib-gnutls
+      - name: print build logs
+        if: ${{ always() }}
+        run: cat build.log
+      - name: print ffbuild logs
+        if: ${{ failure() }}
+        run: '[[ -f ./src/ffmpeg/ffbuild/config.log ]] && tail -50 ./src/ffmpeg/ffbuild/config.log'
+  build-ios-lts-on-macos-monterey:
+    name: ios lts on monterey
     runs-on: macos-12
     strategy:
       matrix:
-        xcode: [ '13.4.1' ]
+        xcode: [ '14.2' ]
         branches: [ 'main', 'development' ]
     defaults:
       run:
@@ -24,19 +50,19 @@ jobs:
       - name: set up xcode
         run: echo "export DEVELOPER_DIR=/Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer" > ~/.xcode.for.ffmpeg.kit.sh
       - name: run the build script
-        run: PATH="/usr/local/opt/bison/bin:$PATH" XML_CATALOG_FILES="/usr/local/etc/xml/catalog" ./ios.sh -x --full --enable-gpl --disable-lib-srt
+        run: PATH="/usr/local/opt/bison/bin:$PATH" XML_CATALOG_FILES="/usr/local/etc/xml/catalog" ./ios.sh -l --full --enable-gpl --disable-lib-srt --disable-lib-gnutls --disable-armv7s --disable-arm64e --disable-i386
       - name: print build logs
         if: ${{ always() }}
         run: cat build.log
       - name: print ffbuild logs
         if: ${{ failure() }}
         run: '[[ -f ./src/ffmpeg/ffbuild/config.log ]] && tail -50 ./src/ffmpeg/ffbuild/config.log'
-  build-ios-lts-on-macos-bigsur:
-    name: ios lts on big sur
-    runs-on: macos-11
+  build-macos-main-on-macos-ventura:
+    name: macos main on ventura
+    runs-on: macos-13
     strategy:
       matrix:
-        xcode: [ '12.4' ]
+        xcode: [ '14.3.1' ]
         branches: [ 'main', 'development' ]
     defaults:
       run:
@@ -50,19 +76,19 @@ jobs:
       - name: set up xcode
         run: echo "export DEVELOPER_DIR=/Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer" > ~/.xcode.for.ffmpeg.kit.sh
       - name: run the build script
-        run: PATH="/usr/local/opt/bison/bin:$PATH" XML_CATALOG_FILES="/usr/local/etc/xml/catalog" ./ios.sh -l --full --enable-gpl --disable-lib-srt
+        run: PATH="/usr/local/opt/bison/bin:$PATH" XML_CATALOG_FILES="/usr/local/etc/xml/catalog" ./macos.sh -x --full --enable-gpl --disable-lib-srt --disable-lib-gnutls
       - name: print build logs
         if: ${{ always() }}
         run: cat build.log
       - name: print ffbuild logs
         if: ${{ failure() }}
         run: '[[ -f ./src/ffmpeg/ffbuild/config.log ]] && tail -50 ./src/ffmpeg/ffbuild/config.log'
-  build-macos-main-on-macos-monterey:
-    name: macos main on monterey
+  build-macos-lts-on-macos-monterey:
+    name: macos lts on monterey
     runs-on: macos-12
     strategy:
       matrix:
-        xcode: [ '13.4.1' ]
+        xcode: [ '14.2' ]
         branches: [ 'main', 'development' ]
     defaults:
       run:
@@ -76,19 +102,19 @@ jobs:
       - name: set up xcode
         run: echo "export DEVELOPER_DIR=/Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer" > ~/.xcode.for.ffmpeg.kit.sh
       - name: run the build script
-        run: PATH="/usr/local/opt/bison/bin:$PATH" XML_CATALOG_FILES="/usr/local/etc/xml/catalog" ./macos.sh -x --full --enable-gpl --disable-lib-srt
+        run: PATH="/usr/local/opt/bison/bin:$PATH" XML_CATALOG_FILES="/usr/local/etc/xml/catalog" ./macos.sh -l --full --enable-gpl --disable-lib-srt --disable-lib-gnutls
       - name: print build logs
         if: ${{ always() }}
         run: cat build.log
       - name: print ffbuild logs
         if: ${{ failure() }}
         run: '[[ -f ./src/ffmpeg/ffbuild/config.log ]] && tail -50 ./src/ffmpeg/ffbuild/config.log'
-  build-macos-lts-on-macos-bigsur:
-    name: macos lts on big sur
-    runs-on: macos-11
+  build-tvos-main-on-macos-ventura:
+    name: tvos main on ventura
+    runs-on: macos-13
     strategy:
       matrix:
-        xcode: [ '12.4' ]
+        xcode: [ '14.3.1' ]
         branches: [ 'main', 'development' ]
     defaults:
       run:
@@ -102,19 +128,19 @@ jobs:
       - name: set up xcode
         run: echo "export DEVELOPER_DIR=/Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer" > ~/.xcode.for.ffmpeg.kit.sh
       - name: run the build script
-        run: PATH="/usr/local/opt/bison/bin:$PATH" XML_CATALOG_FILES="/usr/local/etc/xml/catalog" ./macos.sh -l --full --enable-gpl --disable-lib-srt
+        run: PATH="/usr/local/opt/bison/bin:$PATH" XML_CATALOG_FILES="/usr/local/etc/xml/catalog" ./tvos.sh -x --full --enable-gpl --disable-lib-srt --disable-lib-gnutls
       - name: print build logs
         if: ${{ always() }}
         run: cat build.log
       - name: print ffbuild logs
         if: ${{ failure() }}
         run: '[[ -f ./src/ffmpeg/ffbuild/config.log ]] && tail -50 ./src/ffmpeg/ffbuild/config.log'
-  build-tvos-main-on-macos-monterey:
-    name: tvos main on monterey
+  build-tvos-lts-on-macos-monterey:
+    name: tvos lts on monterey
     runs-on: macos-12
     strategy:
       matrix:
-        xcode: [ '13.4.1' ]
+        xcode: [ '14.2' ]
         branches: [ 'main', 'development' ]
     defaults:
       run:
@@ -128,33 +154,7 @@ jobs:
       - name: set up xcode
         run: echo "export DEVELOPER_DIR=/Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer" > ~/.xcode.for.ffmpeg.kit.sh
       - name: run the build script
-        run: PATH="/usr/local/opt/bison/bin:$PATH" XML_CATALOG_FILES="/usr/local/etc/xml/catalog" ./tvos.sh -x --full --enable-gpl --disable-lib-srt
-      - name: print build logs
-        if: ${{ always() }}
-        run: cat build.log
-      - name: print ffbuild logs
-        if: ${{ failure() }}
-        run: '[[ -f ./src/ffmpeg/ffbuild/config.log ]] && tail -50 ./src/ffmpeg/ffbuild/config.log'
-  build-tvos-lts-on-macos-bigsur:
-    name: tvos lts on big sur
-    runs-on: macos-11
-    strategy:
-      matrix:
-        xcode: [ '12.4' ]
-        branches: [ 'main', 'development' ]
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: ${{ matrix.branches }}
-      - name: prerequisites
-        run: brew install autoconf automake libtool pkg-config curl git doxygen nasm cmake gcc gperf texinfo yasm bison autogen wget gettext meson ninja ragel groff gtk-doc libtasn1 --overwrite
-      - name: set up xcode
-        run: echo "export DEVELOPER_DIR=/Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer" > ~/.xcode.for.ffmpeg.kit.sh
-      - name: run the build script
-        run: PATH="/usr/local/opt/bison/bin:$PATH" XML_CATALOG_FILES="/usr/local/etc/xml/catalog" ./tvos.sh -l --full --enable-gpl --disable-lib-srt
+        run: PATH="/usr/local/opt/bison/bin:$PATH" XML_CATALOG_FILES="/usr/local/etc/xml/catalog" ./tvos.sh -l --full --enable-gpl --disable-lib-srt --disable-lib-gnutls
       - name: print build logs
         if: ${{ always() }}
         run: cat build.log


### PR DESCRIPTION
## Description
use macos-13 in periodic apple builds

## Type of Change
- CI/CD

## Checks
- [x] Changes support all platforms (`Android`, `iOS`, `Linux`, `macOS`, `tvOS`)
- [ ] Breaks existing functionality
- [x] Implementation is completed, not half-done 
- [ ] Is there another PR already created for this feature/bug fix