### PR TITLE
merge react-native v6.0.2 to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,10 @@ the exact version number of `FFmpeg` is obtained using the `git describe --tags`
 
 |    Platforms     |                                 FFmpegKit Version                                 | FFmpeg Version | Release Date |
 |:----------------:|:---------------------------------------------------------------------------------:|:--------------:|:------------:|
+|     Flutter      |   [6.0.3](https://github.com/arthenica/ffmpeg-kit/releases/tag/flutter.v6.0.3)    |      6.0       | Sep 19, 2023 |
+|   React Native   | [6.0.2](https://github.com/arthenica/ffmpeg-kit/releases/tag/react.native.v6.0.2) |      6.0       | Sep 19, 2023 |
 |     Flutter      |   [6.0.2](https://github.com/arthenica/ffmpeg-kit/releases/tag/flutter.v6.0.2)    |      6.0       | Sep 03, 2023 |
-|   React Native   | [6.0.1](https://github.com/arthenica/ffmpeg-kit/releases/tag/react.native.v6.0.1) |      6.0       | Sep 03, 2023  |
+|   React Native   | [6.0.1](https://github.com/arthenica/ffmpeg-kit/releases/tag/react.native.v6.0.1) |      6.0       | Sep 03, 2023 |
 |     Flutter      |   [6.0.1](https://github.com/arthenica/ffmpeg-kit/releases/tag/flutter.v6.0.1)    |      6.0       | Sep 03, 2023 |
 |   React Native   | [6.0.0](https://github.com/arthenica/ffmpeg-kit/releases/tag/react.native.v6.0.0) |      6.0       | Aug 27, 2023 |
 |     Flutter      |   [6.0.0](https://github.com/arthenica/ffmpeg-kit/releases/tag/flutter.v6.0.0)    |      6.0       | Aug 27, 2023 |

--- a/react-native/android/build.gradle
+++ b/react-native/android/build.gradle
@@ -35,8 +35,8 @@ android {
   defaultConfig {
     minSdkVersion safeExtGet('ffmpegKitPackage', 'https').contains("-lts") ? 16 : 24
     targetSdkVersion 33
-    versionCode 601
-    versionName "6.0.1"
+    versionCode 602
+    versionName "6.0.2"
   }
 
   buildTypes {

--- a/react-native/android/gradle.properties
+++ b/react-native/android/gradle.properties
@@ -1,3 +1,3 @@
 android.useAndroidX=true
-ffmpegKit.android.main.version=6.0-1
-ffmpegKit.android.lts.version=6.0-1
+ffmpegKit.android.main.version=6.0-2
+ffmpegKit.android.lts.version=6.0-2

--- a/react-native/package.json
+++ b/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffmpeg-kit-react-native",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "description": "FFmpeg Kit for React Native",
   "main": "src/index",
   "types": "src/index.d.ts",

--- a/react-native/src/index.js
+++ b/react-native/src/index.js
@@ -1611,7 +1611,7 @@ class FFmpegKitFactory {
   }
 
   static getVersion() {
-    return "6.0.1";
+    return "6.0.2";
   }
 
   static getLogRedirectionStrategy(sessionId) {


### PR DESCRIPTION
## Description
merge react-native v6.0.2 to main

## Type of Change
- Patch

## Checks
- [x] Changes support all platforms (`Android`, `iOS`, `Linux`, `macOS`, `tvOS`)
- [ ] Breaks existing functionality
- [x] Implementation is completed, not half-done 
- [ ] Is there another PR already created for this feature/bug fix

## Tests
Tested by the test applications in the ffmpeg-kit-test repo