### PR TITLE
Fix Segfault if SAF is used with concat demuxer

### DIFF
--- a/android/ffmpeg-kit-android-lib/src/main/cpp/ffmpegkit.c
+++ b/android/ffmpeg-kit-android-lib/src/main/cpp/ffmpegkit.c
@@ -575,11 +575,11 @@ int saf_open(int safId) {
     jint getEnvRc = (*globalVm)->GetEnv(globalVm, (void**) &env, JNI_VERSION_1_6);
     if (getEnvRc != JNI_OK) {
         if (getEnvRc != JNI_EDETACHED) {
-            LOGE("Callback thread failed to GetEnv for class %s with rc %d.\n", configClassName, getEnvRc);
+            LOGE("saf_open failed to GetEnv for class %s with rc %d.\n", configClassName, getEnvRc);
             return 0;
         }
         if ((*globalVm)->AttachCurrentThread(globalVm, &env, NULL) != 0) {
-            LOGE("Callback thread failed to AttachCurrentThread for class %s.\n", configClassName);
+            LOGE("saf_open failed to AttachCurrentThread for class %s.\n", configClassName);
             return 0;
         } else {
           attached = true;
@@ -602,12 +602,12 @@ int saf_close(int fd) {
     jint getEnvRc = (*globalVm)->GetEnv(globalVm, (void**) &env, JNI_VERSION_1_6);
     if (getEnvRc != JNI_OK) {
         if (getEnvRc != JNI_EDETACHED) {
-            LOGE("Callback thread failed to GetEnv for class %s with rc %d.\n", configClassName, getEnvRc);
+            LOGE("saf_close failed to GetEnv for class %s with rc %d.\n", configClassName, getEnvRc);
             return 0;
         }
 
         if ((*globalVm)->AttachCurrentThread(globalVm, &env, NULL) != 0) {
-            LOGE("Callback thread failed to AttachCurrentThread for class %s.\n", configClassName);
+            LOGE("saf_close failed to AttachCurrentThread for class %s.\n", configClassName);
             return 0;
         } else {
           attached = true;


### PR DESCRIPTION
## Description
If Storage Access Framework protocol is used with concat demuxer (https://trac.ffmpeg.org/wiki/Concatenate#demuxer) - ffmpeg-kit segfaults as `saf_open` and `saf_close` are called from a separate ffmpeg thread that is not attached with JNI and there are no checks if `GetEnv` was successful.

This PR adds code to attach/detach thread in `saf_open` and `saf_close` that fixes said segfault. After this change concat demuxer works with SAF with no further issues.

## Type of Change
- Bug fix

## Checks
- [X] Changes support all (relevant) platforms (only `Android` is relevant for SAF)
- [ ] Breaks existing functionality
- [X] Implementation is completed, not half-done 
- [ ] Is there another PR already created for this feature/bug fix

## Tests (in Android code)
0. Create SAF links from Android content URIs.
1. Create concat demuxer input file (`mylist.txt`) with said SAF links (even one saf link here is enough to cause segfault):
```
file saf:1.mp4
file saf:2.mp4
```
2. Call ffmpeg concat demuxer like so:
`ffmpeg -y -f concat -safe 0 -protocol_whitelist saf,file,crypto -i mylist.txt -c copy saf:3.mp4`
Segfault will occur (if fix was not applied).