### PR TITLE
Comments indicating how to use a local build of ffmpeg-kit.arr

### DIFF
--- a/flutter/flutter/android/build.gradle
+++ b/flutter/flutter/android/build.gradle
@@ -43,7 +43,7 @@ android {
     lintOptions {
         disable 'GradleCompatible'
     }
-    compileOptions {    
+    compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }

--- a/flutter/flutter/android/build.gradle
+++ b/flutter/flutter/android/build.gradle
@@ -11,6 +11,8 @@ buildscript {
 
 rootProject.allprojects {
     repositories {
+        // To use a local build of ffmpeg-kit.arr, set this to your absolute path.
+        //flatDir { dirs "/YOUR/PATH/TO/ffmpeg-kit/prebuilt/bundle-android-aar/ffmpeg-kit" } 
         google()
         mavenCentral()
     }
@@ -41,7 +43,7 @@ android {
     lintOptions {
         disable 'GradleCompatible'
     }
-    compileOptions {
+    compileOptions {    
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
@@ -49,5 +51,10 @@ android {
 
 dependencies {
     implementation 'androidx.annotation:annotation:1.5.0'
+
+    // To use the public build of ffmpeg-kit
     implementation 'com.arthenica:ffmpeg-kit-https:6.0-2'
+
+    // To use a local build of ffmpeg-kit.arr (see 'repositioris { flatDir }' above!)
+    //implementation(group: 'com.arthenica', name: 'ffmpeg-kit', ext: 'aar')
 }


### PR DESCRIPTION
## Description
These comments show how to use a local build of ffmpeg-kit.arr for flutter, which is a little more tricky than it appears, because directly using local .arr files aren't allowed by gradle.

I would recommend that we link to this build.gradle file from https://github.com/arthenica/ffmpeg-kit/wiki/How-to-Decrease-Binary-Size#hybrid-plugins-flutter-react-native (and perhaps make that section more visible, since it's not clear that vital information for flutter/react is hidden in the How to Decrease Binary Size section!)

NOTE: For the examples, https://github.com/arthenica/ffmpeg-kit-test/pull/60 is also needed.

## Type of Change
- Documentation

## Checks
- [ yes] Changes support all platforms (`Android`, `iOS`, `Linux`, `macOS`, `tvOS`)
- [ no] Breaks existing functionality
- [ yes] Implementation is completed, not half-done 
- [ no] Is there another PR already created for this feature/bug fix

## Tests
`flutter run` on ffmpeg-kit-test flutter local build example.