### PR TITLE
Removing polluting console logs always shown

### DIFF
--- a/react-native/src/index.js
+++ b/react-native/src/index.js
@@ -1904,21 +1904,25 @@ class FFmpegKitInitializer {
       this.#initialized = true;
     }
 
-    console.log("Loading ffmpeg-kit-react-native.");
-
     this.#eventEmitter.addListener(eventLogCallbackEvent, FFmpegKitInitializer.processLogCallbackEvent);
     this.#eventEmitter.addListener(eventStatisticsCallbackEvent, FFmpegKitInitializer.processStatisticsCallbackEvent);
     this.#eventEmitter.addListener(eventCompleteCallbackEvent, FFmpegKitInitializer.processCompleteCallbackEvent);
 
-    FFmpegKitFactory.setLogLevel(await FFmpegKitReactNativeModule.getLogLevel());
-    const version = FFmpegKitFactory.getVersion();
-    const platform = await FFmpegKitConfig.getPlatform();
-    const arch = await ArchDetect.getArch();
-    const packageName = await Packages.getPackageName();
-    await FFmpegKitConfig.enableRedirection();
-    const isLTSPostfix = (await FFmpegKitConfig.isLTSBuild()) ? "-lts" : "";
+    const logLevel = await FFmpegKitReactNativeModule.getLogLevel()
 
-    console.log(`Loaded ffmpeg-kit-react-native-${platform}-${packageName}-${arch}-${version}${isLTSPostfix}.`);
+    FFmpegKitFactory.setLogLevel(logLevel);
+
+
+    if(logLevel === "debug") {
+      const version = FFmpegKitFactory.getVersion();
+      const platform = await FFmpegKitConfig.getPlatform();
+      const arch = await ArchDetect.getArch();
+      const packageName = await Packages.getPackageName();
+      await FFmpegKitConfig.enableRedirection();
+      const isLTSPostfix = (await FFmpegKitConfig.isLTSBuild()) ? "-lts" : "";
+
+      console.log(`Loaded ffmpeg-kit-react-native-${platform}-${packageName}-${arch}-${version}${isLTSPostfix}.`);
+    }
   }
 
 }


### PR DESCRIPTION
## Description
Some console logs are always shown when using the library, which is polluting our logs and is not necessary. To not output some undesired logs, I remove one occurrence and hide the second under logLevel=debug

In our project, I see the below:
![image](https://github.com/user-attachments/assets/4af50974-7d5f-466e-ba71-433705dfc75c)


## Type of Change
- Bug fix

## Checks
- [x] Changes support all platforms (`Android`, `iOS`, `Linux`, `macOS`, `tvOS`)
- [x] Implementation is completed, not half-done 

## Tests
Tested by changing the code in my node_modules, both with logelLevel === debug and without it the code was working fine