### PR TITLE
release cpu_features v0.9.0

### DIFF
--- a/scripts/source.sh
+++ b/scripts/source.sh
@@ -18,7 +18,7 @@ get_library_source() {
     ;;
   cpu-features)
     SOURCE_REPO_URL="https://github.com/arthenica/cpu_features"
-    SOURCE_ID="v0.8.0"
+    SOURCE_ID="v0.9.0"
     SOURCE_TYPE="TAG"
     ;;
   dav1d)


### PR DESCRIPTION

## Description
Updated cpu_features to 0.9.0
This fixes cpu_features cmake error CMP0057 occurring in Android NDK 27

## Type of Change
- Bug fix

## Checks
- [ ] Changes support all platforms (`Android`, `iOS`, `Linux`, `macOS`, `tvOS`)
- [ ] Breaks existing functionality
- [ ] Implementation is completed, not half-done 
- [ ] Is there another PR already created for this feature/bug fix

## Tests
Confirmed compiles successfully with Android NDK 25 and NDK 27