### PR TITLE
Draft: Feat add clear individual session

### DIFF
--- a/apple/src/FFmpegKitConfig.h
+++ b/apple/src/FFmpegKitConfig.h
@@ -376,6 +376,14 @@ typedef NS_ENUM(NSUInteger, Signal) {
 + (NSArray*)getSessions;
 
 /**
+ * <p>Clears the session specified with <code>sessionId</code> from the session history.
+ * <p>Note that callbacks cannot be triggered for deleted sessions.
+ *
+ * @param sessionId session identifier
+ */
++ (void)clearSession:(long)sessionId;
+
+/**
  * <p>Clears all, including ongoing, sessions in the session history.
  * <p>Note that callbacks cannot be triggered for deleted sessions.
  */

--- a/apple/src/FFmpegKitConfig.m
+++ b/apple/src/FFmpegKitConfig.m
@@ -1237,6 +1237,17 @@ int executeFFprobe(long sessionId, NSArray* arguments) {
     return sessionsCopy;
 }
 
++ (void)clearSession:(long)sessionId {
+    [sessionHistoryLock lock];
+    id<Session> session = [self getSession:sessionId];
+    if (session != nil) {
+        [sessionHistoryList removeObject:session];
+        [sessionHistoryMap removeObjectForKey:[NSNumber numberWithLong:sessionId]];
+    }
+    
+    [sessionHistoryLock unlock];
+}
+
 + (void)clearSessions {
     [sessionHistoryLock lock];
 

--- a/flutter/flutter/ios/Classes/FFmpegKitFlutterPlugin.m
+++ b/flutter/flutter/ios/Classes/FFmpegKitFlutterPlugin.m
@@ -395,6 +395,12 @@ extern int const AbstractSessionDefaultTimeoutForAsynchronousMessagesInTransmit;
     [self getSessions:result];
   } else if ([@"clearSessions" isEqualToString:call.method]) {
     [self clearSessions:result];
+  } else if ([@"clearSession" isEqualToString:call.method]) {
+    if (sessionId != nil) {
+      [self clearSession:sessionId result:result];
+    } else {
+      result([FlutterError errorWithCode:@"INVALID_SESSION" message:@"Invalid session id." details:nil]);
+    }
   } else if ([@"getSessionsByState" isEqualToString:call.method]) {
     NSNumber* stateIndex = call.arguments[@"state"];
     if (stateIndex != nil) {
@@ -907,6 +913,11 @@ extern int const AbstractSessionDefaultTimeoutForAsynchronousMessagesInTransmit;
 
 - (void)getSessions:(FlutterResult)result {
   result([FFmpegKitFlutterPlugin toSessionArray:[FFmpegKitConfig getSessions]]);
+}
+
+- (void)clearSession:(NSNumber*)sessionId result:(FlutterResult)result {
+  [FFmpegKitConfig clearSession:[sessionId longValue]];
+  result(nil);
 }
 
 - (void)clearSessions:(FlutterResult)result {

--- a/flutter/flutter/lib/ffmpeg_kit_config.dart
+++ b/flutter/flutter/lib/ffmpeg_kit_config.dart
@@ -496,6 +496,18 @@ class FFmpegKitConfig {
     }
   }
 
+  /// Deletes a session from the session history.
+  /// Note that callbacks cannot be triggered for deleted sessions.
+  static Future<void> clearSession(int sessionId) async {
+    try {
+      await init();
+      return _platform.clearSession(sessionId);
+    } on PlatformException catch (e, stack) {
+      print("Plugin clearSession error: ${e.message}");
+      return Future.error("clearSession failed.", stack);
+    }
+  }
+
   /// Clears all, including ongoing, sessions in the session history.
   /// Note that callbacks cannot be triggered for deleted sessions.
   static Future<void> clearSessions() async {

--- a/flutter/flutter_platform_interface/lib/ffmpeg_kit_flutter_platform_interface.dart
+++ b/flutter/flutter_platform_interface/lib/ffmpeg_kit_flutter_platform_interface.dart
@@ -272,6 +272,10 @@ abstract class FFmpegKitPlatform extends PlatformInterface {
         'ffmpegKitConfigGetSessions() has not been implemented!');
   }
 
+  Future<void> clearSession(int sessionId) async {
+    throw UnimplementedError('clearSession() has not been implemented!');
+  }
+
   Future<void> clearSessions() async {
     throw UnimplementedError('clearSessions() has not been implemented!');
   }

--- a/flutter/flutter_platform_interface/lib/method_channel_ffmpeg_kit_flutter.dart
+++ b/flutter/flutter_platform_interface/lib/method_channel_ffmpeg_kit_flutter.dart
@@ -244,6 +244,10 @@ class MethodChannelFFmpegKit extends FFmpegKitPlatform {
       _channel.invokeMethod<List<dynamic>>('getSessions');
 
   @override
+  Future<void> clearSession(int sessionId) async =>
+      _channel.invokeMethod<void>('clearSession', {'sessionId': sessionId});
+
+  @override
   Future<void> clearSessions() async =>
       _channel.invokeMethod<void>('clearSessions');
 


### PR DESCRIPTION
## Description
Fixes #1066

## Type of Change
- New feature

## Checks
- [ ] Changes support all platforms (`Android`, `iOS`, `Linux`, `macOS`, `tvOS`)
- [x] Does not break existing functionality
- [ ] Implementation is completed, not half-done 
- [ ] Is there another PR already created for this feature/bug fix

## Tests
1. Create any ffmpeg session
2. Confirm the session exists with `FFmpegKitConfig.getSessions();` or equivalent 
3. At any point, call `FFmpegKitConfig.clearSession(sessionId);` or equivalent
4. Call `FFmpegKitConfig.getSessions();` again
5. Confirm the session is not there anymore